### PR TITLE
Register named options as keyed

### DIFF
--- a/src/Grace.DependencyInjection.Extensions/Grace.DependencyInjection.Extensions.csproj
+++ b/src/Grace.DependencyInjection.Extensions/Grace.DependencyInjection.Extensions.csproj
@@ -30,12 +30,20 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(OS)' == 'Windows_NT'">
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-62909-01" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Grace" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="1.0.2" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.0'">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="1.1.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.2.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Had to use conditional compilation since named options are not in Microsoft.Extensions.Options.ConfigurationExtensions that targets .NET Standard 1.x.

Maybe it's time to remove .NET Standard 1.x support?