### PR TITLE
.net 8.0 support

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <Authors>Ian Johnson</Authors>    
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+</Project>

--- a/src/Grace.AspNetCore.MVC/Grace.AspNetCore.MVC.csproj
+++ b/src/Grace.AspNetCore.MVC/Grace.AspNetCore.MVC.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <Description>MVC extensions for Grace DI container</Description>
     <VersionPrefix>6.0.3</VersionPrefix>
-    <Authors>Ian Johnson</Authors>
     <TargetFramework>net6.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Grace.AspNetCore.MVC</AssemblyName>

--- a/src/Grace.DependencyInjection.Extensions/Grace.DependencyInjection.Extensions.csproj
+++ b/src/Grace.DependencyInjection.Extensions/Grace.DependencyInjection.Extensions.csproj
@@ -34,8 +34,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grace" Version="8.0.0-RC837" />
-	<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Grace" Version="8.0.0-RC838" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Grace.DependencyInjection.Extensions/Grace.DependencyInjection.Extensions.csproj
+++ b/src/Grace.DependencyInjection.Extensions/Grace.DependencyInjection.Extensions.csproj
@@ -35,7 +35,7 @@
 
   <ItemGroup>
     <PackageReference Include="Grace" Version="8.0.0-RC837" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
+	<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Grace.DependencyInjection.Extensions/Grace.DependencyInjection.Extensions.csproj
+++ b/src/Grace.DependencyInjection.Extensions/Grace.DependencyInjection.Extensions.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <Description>ASP.Net Core DI extension for Grace container</Description>
     <VersionPrefix>6.0.3</VersionPrefix>
-    <Authors>Ian Johnson</Authors>
     <TargetFrameworks>net462;net6.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Grace.DependencyInjection.Extensions</AssemblyName>

--- a/src/Grace.DependencyInjection.Extensions/GraceRegistration.cs
+++ b/src/Grace.DependencyInjection.Extensions/GraceRegistration.cs
@@ -223,7 +223,12 @@ namespace Grace.DependencyInjection.Extensions
             , IAsyncDisposable
 #endif
         {
-            private readonly IExportLocatorScope _injectionScope;
+            private readonly GraceServiceProvider _serviceProvider;
+
+            /// <summary>
+            /// Service provider
+            /// </summary>
+            public IServiceProvider ServiceProvider => _serviceProvider;            
 
             /// <summary>
             /// Default constructor
@@ -231,28 +236,17 @@ namespace Grace.DependencyInjection.Extensions
             /// <param name="injectionScope"></param>
             public GraceServiceScope(IExportLocatorScope injectionScope)
             {
-                _injectionScope = injectionScope;
-
-                ServiceProvider = injectionScope;
+                // Need to wrap IServiceProvider to implement 
+                // MS extensions interface IKeyedServiceProvider 
+                _serviceProvider = new GraceServiceProvider(injectionScope);
             }
-
-            /// <summary>
-            /// Service provider
-            /// </summary>
-            public IServiceProvider ServiceProvider { get; }
 
             // This code added to correctly implement the disposable pattern.
-            public void Dispose()
-            {
-                _injectionScope.Dispose();
-            }
+            public void Dispose() => _serviceProvider.Dispose();
 
 #if NET6_0_OR_GREATER
             // This code added to correctly and asynchronously implement the disposable pattern.
-            public ValueTask DisposeAsync()
-            {
-                return _injectionScope.DisposeAsync();
-            }
+            public ValueTask DisposeAsync() => _serviceProvider.DisposeAsync();
 #endif
         }
 

--- a/src/Grace.DependencyInjection.Extensions/GraceRegistration.cs
+++ b/src/Grace.DependencyInjection.Extensions/GraceRegistration.cs
@@ -101,33 +101,23 @@ namespace Grace.DependencyInjection.Extensions
         private static IFluentExportStrategyConfiguration ConfigureLifetime(
             this IFluentExportStrategyConfiguration configuration, ServiceLifetime lifetime)
         {
-            switch (lifetime)
+            return lifetime switch
             {
-                case ServiceLifetime.Scoped:
-                    return configuration.Lifestyle.SingletonPerScope();
-
-                case ServiceLifetime.Singleton:
-                    return configuration.Lifestyle.Singleton();
-
-                default:
-                    return configuration;
-            }
+                ServiceLifetime.Scoped => configuration.Lifestyle.SingletonPerScope(),
+                ServiceLifetime.Singleton => configuration.Lifestyle.Singleton(),
+                _ => configuration,
+            };
         }
 
         private static IFluentExportInstanceConfiguration<T> ConfigureLifetime<T>(
             this IFluentExportInstanceConfiguration<T> configuration, ServiceLifetime lifecycleKind)
         {
-            switch (lifecycleKind)
+            return lifecycleKind switch
             {
-                case ServiceLifetime.Scoped:
-                    return configuration.Lifestyle.SingletonPerScope();
-
-                case ServiceLifetime.Singleton:
-                    return configuration.Lifestyle.Singleton();
-
-                default:
-                    return configuration;
-            }
+                ServiceLifetime.Scoped => configuration.Lifestyle.SingletonPerScope(),
+                ServiceLifetime.Singleton => configuration.Lifestyle.Singleton(),
+                _ => configuration,
+            };
         }
 
         /// <summary>
@@ -272,22 +262,16 @@ namespace Grace.DependencyInjection.Extensions
 
             public bool IsService(Type serviceType)
             {
-                if (serviceType.IsGenericTypeDefinition)
-                {
-                    return false;
-                }
-
-                return _exportLocatorScope.CanLocate(serviceType);
+                return serviceType.IsGenericTypeDefinition
+                    ? false
+                    : _exportLocatorScope.CanLocate(serviceType);
             }
 
             public bool IsKeyedService(Type serviceType, object serviceKey)
             {
-                if (serviceType.IsGenericTypeDefinition)
-                {
-                    return false;
-                }
-
-                return _exportLocatorScope.CanLocate(serviceType, key: serviceKey);
+                return serviceType.IsGenericTypeDefinition 
+                    ? false 
+                    : _exportLocatorScope.CanLocate(serviceType, key: serviceKey);
             }
         }
     }

--- a/src/Grace.DependencyInjection.Extensions/GraceRegistration.cs
+++ b/src/Grace.DependencyInjection.Extensions/GraceRegistration.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 #endif
 using Microsoft.Extensions.DependencyInjection;
+using Grace.DependencyInjection.Attributes;
 using Grace.DependencyInjection.Attributes.Interfaces;
 
 namespace Grace.DependencyInjection.Extensions
@@ -63,7 +64,11 @@ namespace Grace.DependencyInjection.Extensions
                     }
                     else if (descriptor.KeyedImplementationFactory != null)
                     {
-                        c.ExportFactory(descriptor.KeyedImplementationFactory)
+                        // Adds [ImportKey] on second parameter so that Grace DelegateWrapperStrategy will pass the imported key
+                        var factory = (IServiceProvider services, [ImportKey] object key) => 
+                            descriptor.KeyedImplementationFactory(services, key);
+
+                        c.ExportFactory(factory)
                             .AsKeyed(descriptor.ServiceType, key)
                             .ConfigureLifetime(descriptor.Lifetime);
                     }

--- a/src/Grace.DependencyInjection.Extensions/GraceRegistration.cs
+++ b/src/Grace.DependencyInjection.Extensions/GraceRegistration.cs
@@ -40,23 +40,47 @@ namespace Grace.DependencyInjection.Extensions
         {
             foreach (var descriptor in descriptors)
             {
-                if (descriptor.ImplementationType != null)
+                if (descriptor.IsKeyedService)
                 {
-                    c.Export(descriptor.ImplementationType)
-                        .As(descriptor.ServiceType)
-                        .ConfigureLifetime(descriptor.Lifetime);
-                }
-                else if (descriptor.ImplementationFactory != null)
-                {
-                    c.ExportFactory(descriptor.ImplementationFactory)
-                        .As(descriptor.ServiceType)
-                        .ConfigureLifetime(descriptor.Lifetime);
+                    if (descriptor.KeyedImplementationType != null)
+                    {
+                        c.Export(descriptor.KeyedImplementationType)
+                            .AsKeyed(descriptor.ServiceType, descriptor.ServiceKey)
+                            .ConfigureLifetime(descriptor.Lifetime);
+                    }
+                    else if (descriptor.KeyedImplementationFactory != null)
+                    {
+                        c.ExportFactory(descriptor.KeyedImplementationFactory)
+                            .AsKeyed(descriptor.ServiceType, descriptor.ServiceKey)
+                            .ConfigureLifetime(descriptor.Lifetime);
+                    }
+                    else
+                    {
+                        c.ExportInstance(descriptor.KeyedImplementationInstance)
+                            .AsKeyed(descriptor.ServiceType, descriptor.ServiceKey)
+                            .ConfigureLifetime(descriptor.Lifetime);
+                    }
                 }
                 else
                 {
-                    c.ExportInstance(descriptor.ImplementationInstance)
-                        .As(descriptor.ServiceType)
-                        .ConfigureLifetime(descriptor.Lifetime);
+                    if (descriptor.ImplementationType != null)
+                    {
+                        c.Export(descriptor.ImplementationType)
+                            .As(descriptor.ServiceType)
+                            .ConfigureLifetime(descriptor.Lifetime);
+                    }
+                    else if (descriptor.ImplementationFactory != null)
+                    {
+                        c.ExportFactory(descriptor.ImplementationFactory)
+                            .As(descriptor.ServiceType)
+                            .ConfigureLifetime(descriptor.Lifetime);
+                    }
+                    else
+                    {
+                        c.ExportInstance(descriptor.ImplementationInstance)
+                            .As(descriptor.ServiceType)
+                            .ConfigureLifetime(descriptor.Lifetime);
+                    }
                 }
             }
         }
@@ -94,7 +118,7 @@ namespace Grace.DependencyInjection.Extensions
         /// <summary>
         /// Service provider for Grace
         /// </summary>
-        private class GraceServiceProvider 
+        private class GraceServiceProvider
             : IServiceProvider
             , IDisposable
 #if NET6_0_OR_GREATER

--- a/src/Grace.DependencyInjection.Extensions/GraceRegistration.cs
+++ b/src/Grace.DependencyInjection.Extensions/GraceRegistration.cs
@@ -32,17 +32,14 @@ namespace Grace.DependencyInjection.Extensions
         {
             exportLocator.Configure(c =>
             {
-#if NET6_0_OR_GREATER
                 c.Export<ServiceProviderIsServiceImpl>()
                     .As<IServiceProviderIsService>()
                     .As<IServiceProviderIsKeyedService>();
-#endif
 
                 c.ExcludeTypeFromAutoRegistration(nameof(Microsoft) + ".*");
                 c.Export<GraceServiceProvider>().As<IServiceProvider>().ExternallyOwned();
                 c.Export<GraceLifetimeScopeServiceScopeFactory>().As<IServiceScopeFactory>().Lifestyle.Singleton();
                 Register(c, descriptors);
-
             });
 
             return exportLocator.Locate<IServiceProvider>();
@@ -111,9 +108,10 @@ namespace Grace.DependencyInjection.Extensions
 
                 case ServiceLifetime.Singleton:
                     return configuration.Lifestyle.Singleton();
-            }
 
-            return configuration;
+                default:
+                    return configuration;
+            }
         }
 
         private static IFluentExportInstanceConfiguration<T> ConfigureLifetime<T>(
@@ -126,9 +124,10 @@ namespace Grace.DependencyInjection.Extensions
 
                 case ServiceLifetime.Singleton:
                     return configuration.Lifestyle.Singleton();
-            }
 
-            return configuration;
+                default:
+                    return configuration;
+            }
         }
 
         /// <summary>
@@ -262,8 +261,6 @@ namespace Grace.DependencyInjection.Extensions
 #endif
         }
 
-
-#if NET6_0_OR_GREATER
         private class ServiceProviderIsServiceImpl : IServiceProviderIsKeyedService
         {
             private readonly IExportLocatorScope _exportLocatorScope;
@@ -293,7 +290,5 @@ namespace Grace.DependencyInjection.Extensions
                 return _exportLocatorScope.CanLocate(serviceType, key: serviceKey);
             }
         }
-#endif
     }
-
 }

--- a/test/Grace.DependencyInjection.Extensions.Tests/Grace.DependencyInjection.Extensions.Tests.csproj
+++ b/test/Grace.DependencyInjection.Extensions.Tests/Grace.DependencyInjection.Extensions.Tests.csproj
@@ -19,7 +19,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Specification.Tests" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Specification.Tests" Version="8.0.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
   </ItemGroup>
 

--- a/test/Grace.DependencyInjection.Extensions.Tests/GraceContainerTests.cs
+++ b/test/Grace.DependencyInjection.Extensions.Tests/GraceContainerTests.cs
@@ -11,7 +11,7 @@ namespace Grace.DependencyInjection.Extensions.Tests
         {
             DependencyInjectionContainer container = new DependencyInjectionContainer();
 
-            return  container.Populate(serviceCollection);
+            return container.Populate(serviceCollection);
         }
     }
 #endif

--- a/test/Grace.DependencyInjection.Extensions.Tests/GraceContainerTests.cs
+++ b/test/Grace.DependencyInjection.Extensions.Tests/GraceContainerTests.cs
@@ -4,7 +4,6 @@ using System;
 
 namespace Grace.DependencyInjection.Extensions.Tests
 {
-#if NET6_0_OR_GREATER
     public class GraceContainerTests : DependencyInjectionSpecificationTests
     {
         protected override IServiceProvider CreateServiceProvider(IServiceCollection serviceCollection)
@@ -14,5 +13,4 @@ namespace Grace.DependencyInjection.Extensions.Tests
             return container.Populate(serviceCollection);
         }
     }
-#endif
 }

--- a/test/Grace.DependencyInjection.Extensions.Tests/GraceContainerTests.cs
+++ b/test/Grace.DependencyInjection.Extensions.Tests/GraceContainerTests.cs
@@ -8,9 +8,8 @@ namespace Grace.DependencyInjection.Extensions.Tests
     {
         protected override IServiceProvider CreateServiceProvider(IServiceCollection serviceCollection)
         {
-            DependencyInjectionContainer container = new DependencyInjectionContainer();
-
-            return container.Populate(serviceCollection);
+            return new DependencyInjectionContainer()
+                .Populate(serviceCollection);
         }
     }
 }

--- a/test/Grace.DependencyInjection.Extensions.Tests/GraceKeyedContainerTests.cs
+++ b/test/Grace.DependencyInjection.Extensions.Tests/GraceKeyedContainerTests.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Specification;
+using System;
+
+namespace Grace.DependencyInjection.Extensions.Tests
+{
+#if NET6_0_OR_GREATER
+    public class GraceKeyedContainerTests : KeyedDependencyInjectionSpecificationTests
+    {
+        protected override IServiceProvider CreateServiceProvider(IServiceCollection serviceCollection)
+        {
+            DependencyInjectionContainer container = new DependencyInjectionContainer();
+
+            return container.Populate(serviceCollection);
+        }
+    }
+#endif
+}

--- a/test/Grace.DependencyInjection.Extensions.Tests/GraceKeyedContainerTests.cs
+++ b/test/Grace.DependencyInjection.Extensions.Tests/GraceKeyedContainerTests.cs
@@ -4,7 +4,6 @@ using System;
 
 namespace Grace.DependencyInjection.Extensions.Tests
 {
-#if NET6_0_OR_GREATER
     public class GraceKeyedContainerTests : KeyedDependencyInjectionSpecificationTests
     {
         protected override IServiceProvider CreateServiceProvider(IServiceCollection serviceCollection)
@@ -14,5 +13,4 @@ namespace Grace.DependencyInjection.Extensions.Tests
             return container.Populate(serviceCollection);
         }
     }
-#endif
 }

--- a/test/Grace.DependencyInjection.Extensions.Tests/GraceKeyedContainerTests.cs
+++ b/test/Grace.DependencyInjection.Extensions.Tests/GraceKeyedContainerTests.cs
@@ -8,9 +8,8 @@ namespace Grace.DependencyInjection.Extensions.Tests
     {
         protected override IServiceProvider CreateServiceProvider(IServiceCollection serviceCollection)
         {
-            DependencyInjectionContainer container = new DependencyInjectionContainer();
-
-            return container.Populate(serviceCollection);
+            return new DependencyInjectionContainer()
+                .Populate(serviceCollection);
         }
     }
 }


### PR DESCRIPTION
I have bootstrapped the work to support keyed services in .net 8.0. 
Please note that this is incomplete as there are new features that I'm not sure how to best add to Grace:

- [x]  `ServiceDescriptor` has new members (`IsKeyedService` and co.), to register keyed services.
- [x] `GraceServiceProvider` should implement `IKeyedServiceProvider`, an extension of `IServiceProvider`. 
It looks like .net still always injects `IServiceProvider` but then checks if `IKeyedServiceProvider` is implemented when keyed services are requested. Extension methods `GetKeyedService` are defined on `IServiceProvider` based on this principle.
- [x] `ServiceProviderIsServiceImpl` should implement extended interface `IServiceProviderIsKeyedService`.
Skimming .net source code, it looks like this is downcasted from `IServiceProviderIsService` but `IServiceProviderIsKeyedService` is also considered a legit exported type, so I exported this interface explicitly, too.
- [x] `FromKeyedServiceAttribute` I feel like this BCL attribute needs to be understood by Grace, as it indicates the imported key when resolving services that were registered through BCL `ServiceCollection` apis. 
Not sure what the best code is here: I guess in `GraceRegistration.Register()` we need to look at ctor parameters to identify which ones have `[FromKeyedServices]` and configure the strategy accordingly?
Also wondering how this interacts with auto-registration: can any type not going through `GraceRegistration.Register()` use `[FromKeyedServices]`? That feels more robust but then I'm not sure how to teach core Grace about this attribute in a decoupled fashion.
- [x] `KeyedService.AnyKey` This is a well-known singleton, that when used during registration (i.e. `container.AddKeyedService<T>(KeyedService.AnyKey)`) indicates that this registration should match all keys during resolution. I think Grace has no such feature at the moment.
My understanding of this new feature is that when locating _one_ instance, matching keys have priority. Then if no such key exist then `AnyKey` registrations are considered. When locating _all_ instances (e.g. `IEnumerable<T>`), then both matching keys and `AnyKey` must be returned.
It might seem weird to resolve a registration regardless of its key, but when you combine this with the next feature `ServiceKeyAttribute`, it opens up interesting use-cases as the ctor can be aware of the key being created.
Note that `AnyKey` must not be conflated with `null`. .net considers `null` as a non-keyed registration. Also when doing a non-keyed `Locate<T>()`, `AnyKey` registrations must NOT be included.
- [x] `ServiceKeyAttribute` This is another BCL attribute that Grace needs to know about: it can be used on a `string` ctor parameter and the parameter must receive the service key being created. This works nicely in combination with `AnyKey`.